### PR TITLE
修复登录后主页加载问题

### DIFF
--- a/pages/Default/Index/Default_Index.js
+++ b/pages/Default/Index/Default_Index.js
@@ -119,7 +119,11 @@ Page({
    * 生命周期函数--监听页面显示
    */
   onShow() {
-
+    // 从登录页跳转回来时会触发
+    if (typeof this.getTabBar === 'function' && this.getTabBar()) {
+      this.getTabBar().setData({ selected: 0 });
+    }
+    this.loadTherapistsData();
   },
 
   /**


### PR DESCRIPTION
原来登录之后，会跳转到首页，此时没有推荐咨询师，必须重新编译了才能看到，现在不会了